### PR TITLE
Ignore errors when posting a typing indicator

### DIFF
--- a/Source/Microsoft.Teams.Apps.ExpertFinder/Bots/ExpertFinderBot.cs
+++ b/Source/Microsoft.Teams.Apps.ExpertFinder/Bots/ExpertFinderBot.cs
@@ -586,9 +586,17 @@ namespace Microsoft.Teams.Apps.ExpertFinder.Bots
         /// <returns>A task that represents typing indicator activity.</returns>
         private async Task SendTypingIndicatorAsync(ITurnContext turnContext)
         {
-            var typingActivity = turnContext.Activity.CreateReply(locale: CultureInfo.CurrentCulture.Name);
-            typingActivity.Type = ActivityTypes.Typing;
-            await turnContext.SendActivityAsync(typingActivity).ConfigureAwait(false);
+            try
+            {
+                var typingActivity = turnContext.Activity.CreateReply();
+                typingActivity.Type = ActivityTypes.Typing;
+                await turnContext.SendActivityAsync(typingActivity);
+            }
+            catch (Exception ex)
+            {
+                // Do not fail on errors sending the typing indicator
+                this.logger.LogWarning(ex, $"Failed to send a typing indicator: {ex.Message}");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Bots posting typing-indicators to users in Europe region are receiving 502s at this time, as typing indicator support is scaled down temporarily to provide more resources to other scenarios.

This change suppresses the exception thrown by sending the typing indicator, so that a failure to post the indicator is not a fatal error. The exception is still logged to App Insights so that the admin can monitor the ultimate resolution of this issue.