### PR TITLE
Update application insights key name

### DIFF
--- a/Deployment/azuredeploy.json
+++ b/Deployment/azuredeploy.json
@@ -216,7 +216,7 @@
               "value": "[parameters('tenantId')]"
             },
             {
-              "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
+              "name": "AppInsightsInstrumentationKey",
               "value": "[reference(resourceId('Microsoft.Insights/components/', variables('botAppInsightsName')), '2015-05-01').InstrumentationKey]"
             },
             {


### PR DESCRIPTION
[Fix] - Application insights key name in ARM template deployment file is mismatched with the appSettings.json file in bot service web project. Updating the key name as "AppInsightsInstrumentationKey" to align with the configuration file.